### PR TITLE
Add Errno::EHOSTDOWN to connection errors

### DIFF
--- a/lib/rest/error.rb
+++ b/lib/rest/error.rb
@@ -40,6 +40,7 @@ module REST
           Errno::ECONNABORTED
           Errno::ECONNREFUSED
           Errno::ECONNRESET
+          Errno::EHOSTDOWN
           Errno::EHOSTUNREACH
           Errno::EINVAL
           Errno::ENETUNREACH


### PR DESCRIPTION
This errno occurs when a connection was blocked by a firewall, e.g. LittleSnitch on OS X.
nap did not catch the Errno::EHOSTDOWN exception before. This patch fixes it.

See also: https://github.com/CocoaPods/cocoapods-stats/pull/18

Signed-off-by: Clemens Gruber <clemensgru@gmail.com>