### PR TITLE
Support passing a body for delete

### DIFF
--- a/lib/rest/request.rb
+++ b/lib/rest/request.rb
@@ -173,10 +173,7 @@ module REST
     # Performs the actual request and returns a REST::Response object with the response
     def perform
       self.request = request_for_verb
-      
-      if [:patch, :put, :post].include?(verb)
-        request.body = body
-      end
+      request.body = body
       
       if options[:username] and options[:password]
         request.basic_auth(options[:username], options[:password])

--- a/test/rest_request_test.rb
+++ b/test/rest_request_test.rb
@@ -29,9 +29,11 @@ describe "A REST Request" do
   end
 
   it "should GET a resource including a query" do
-    request = REST::Request.new(:get, URI.parse('http://example.com/resources?q=first'))
+    body = "hello"
+    request = REST::Request.new(:get, URI.parse('http://example.com/resources?q=first'), body)
     response = request.perform
-    
+   
+    request.request.body.should == body 
     request.request.path.should == '/resources?q=first'
     response.status_code.should == 200
     response.body.should == 'It works!'
@@ -45,9 +47,11 @@ describe "A REST Request" do
   end
   
   it "should DELETE a resource" do
-    request = REST::Request.new(:delete, URI.parse('http://example.com/resources/1'))
+    body="hello"
+    request = REST::Request.new(:delete, URI.parse('http://example.com/resources/1'), body)
     response = request.perform
     
+    request.request.body.should == body 
     response.status_code.should == 200
   end
   


### PR DESCRIPTION
To quote the [GitHub API](https://developer.github.com/v3/#parameters)

> For POST, PATCH, PUT, and DELETE requests, parameters not included in the URL should be encoded as JSON with a Content-Type of 'application/json':

> `curl -i -u username -d '{"scopes":["public_repo"]}' https://api.github.com/authorizations`

I assume they know more than me about the HTTP spec, word on [this StackOverflow](http://stackoverflow.com/questions/299628/is-an-entity-body-allowed-for-an-http-delete-request) is that this is allowed post HTTP 1.1.

Looks like my editor killed some whitespace, can remove that if needed.